### PR TITLE
Canvas-based schedule renderer

### DIFF
--- a/components/Schedule.vue
+++ b/components/Schedule.vue
@@ -94,11 +94,26 @@ export default {
       // Get the length of each day
       const dayLengths = eventsDayGrouped.map((events) => {
         const sorted = events.sort(firstBy('start'))
-        const length = sorted[sorted.length - 1].end - sorted[0].start
+        const length =
+          sorted[sorted.length - 1].end - this.earliestStartTimeOfWeek
         return length
       })
       // Get the max length
       return Math.max(...dayLengths)
+    },
+    earliestStartTimeOfWeek() {
+      // Mapping of day: events[]
+      const eventsByDay = groupBy(this.events, 'day')
+      // List of events[] grouped by day
+      const eventsDayGrouped = Object.values(eventsByDay)
+      // Get the length of each day
+      const dayStarts = eventsDayGrouped.map((events) => {
+        const sorted = events.sort(firstBy('start'))
+        const dayStart = sorted[0].start
+        return dayStart
+      })
+      // Get the max length
+      return Math.min(...dayStarts)
     },
     canvasConfig() {
       // Trick to allow for recomputation of values on window resize
@@ -158,12 +173,9 @@ export default {
       let x = baseWidth * event.day - baseWidth
       // If the event is in Q2, we need to offset it to the right
       if (event.week_type === 'Q2') x += baseWidth / 2
-      // Get the start time of the first event for this day
-      const eventsOfDay = this.events.filter((e) => e.day === event.day)
-      const startOfDay = Math.min(...eventsOfDay.map((e) => e.start))
       // Get the difference between the start of the day and the start of this event,
       // Multiply by the height factor
-      const y = ((event.start - startOfDay) / 60) * 1.5
+      const y = ((event.start - this.earliestStartTimeOfWeek) / 60) * 1.5
       return { x, y }
     },
     resolveRect(event) {

--- a/components/Schedule.vue
+++ b/components/Schedule.vue
@@ -1,65 +1,30 @@
 <template lang="pug">
-  .schedule(:class="{ mnml: false }")
-    ModalAddEvent(
-      v-model="editingEvent"
-      action="edit"
-      @submit="patch({ modifications: editingEvent, uuid: editingEvent.uuid })"
-      @delete="del({ uuid: editingEvent.uuid })"
+.--schedule
+  ModalAddEvent(
+    v-model="editingEvent"
+    action="edit"
+    @submit="patch({ modifications: editingEvent, uuid: editingEvent.uuid })"
+    @delete="del({ uuid: editingEvent.uuid })"
+  )
+  v-stage(:config="canvasConfig"): v-layer(@click="handleEventClick")
+    v-rect(
+      v-for="(day, i) in days" :key="day"
+      
     )
-    table
-      thead
-        tr.days
-          td.empty &nbsp;
-          td(
-            v-for="dayName in dayNames"
-            colspan="2"
-          ) {{ dayName }}
-        tr.week-types
-          td.empty &nbsp;
-          template(
-            v-for="dayName in dayNames"
-          )
-            td.week-type Paire
-            td.week-type Impaire
-      tbody
-        tr(
-          v-for="minute in minutes"
-          :class="{ 'new-hour': minute.time.endsWith(':00'), 'has-events': minute.hasEvents }"
-          :data-time="minute.time"
-        )
-          td.time(
-            v-if="minute.time.endsWith(':00')"
-            rowspan="60"
-          ) {{ minute.time }}
-          template(v-if="minute.hasEvents")
-            template(v-for="(dayName, day) in dayNames")
-              td.event(
-                v-for="event in minute.events[day+1]"
-                v-bind="cellAttrs(event)"
-                @click="cellOnClick(event)"
-              )
-                template(v-if="!event.empty")
-                  .subject {{ event.subject.name }}
-                  .room {{ event.room }}
-
+    template(v-for="event in events")
+      v-rect(
+        :key="event.uuid"
+        :config="resolveRect(event)"
+      )
+      v-text(
+        :config="resolveText(event)"
+      )
 </template>
 
 <script>
-import { mapState, mapGetters, mapActions } from 'vuex'
-import {
-  setSeconds,
-  setMinutes,
-  setHours,
-  format,
-  startOfWeek,
-  endOfWeek,
-  addMinutes,
-  differenceInMinutes,
-  isWithinInterval,
-  parse
-} from 'date-fns'
-// eslint-disable-next-line no-unused-vars
+import { mapGetters } from 'vuex'
 import groupBy from 'lodash.groupby'
+import { firstBy } from 'thenby'
 import ModalAddEvent from '~/components/ModalAddEvent.vue'
 
 export default {
@@ -80,6 +45,22 @@ export default {
     namespace: {
       type: String,
       default: ''
+    },
+    events: {
+      type: Object,
+      default: () => [
+        {
+          day: 1,
+          room: 'L666',
+          start: 8 * 3600,
+          end: 9 * 3600,
+          subject: {
+            name: 'English',
+            color: 'blue'
+          },
+          week_type: 'Q1'
+        }
+      ]
     }
   },
   data() {
@@ -97,231 +78,129 @@ export default {
         ...defaults,
         uuid: null
       },
-      dayNames: [
-        'Lundi',
-        'Mardi',
-        'Mercredi',
-        'Jeudi',
-        'Vendredi',
-        'Samedi'
-        // 'Dimanche'
-      ]
+      recomputeCanvasWidth: 1
     }
   },
   computed: {
-    ...mapState(['now']),
-    ...mapGetters('schedule', ['coursesIn']),
-    scheduleStart() {
-      let start = new Date()
-      start = setHours(start, 8)
-      start = setMinutes(start, 0)
-      start = setSeconds(start, 0)
-      return start
+    days() {
+      return null
     },
-    scheduleEnd() {
-      let end = new Date()
-      end = setHours(end, 19)
-      end = setMinutes(end, 0)
-      end = setSeconds(end, 0)
-      return end
+    heightOfLongestDay() {
+      // Mapping of day: events[]
+      const eventsByDay = groupBy(this.events, 'day')
+      console.log(eventsByDay)
+      // List of events[] grouped by day
+      const eventsDayGrouped = Object.values(eventsByDay)
+      // Get the length of each day
+      const dayLengths = eventsDayGrouped.map((events) => {
+        const sorted = events.sort(firstBy('start'))
+        const length = sorted[sorted.length - 1].end - sorted[0].start
+        return length
+      })
+      // Get the max length
+      return Math.max(...dayLengths)
     },
-    emptyMinutes() {
-      // Create an object <time>: [] with time being every minute from scheduleStart to scheduleEnd
-      const keys = []
-      let currentTime = this.scheduleStart
-      while (currentTime.getTime() <= this.scheduleEnd.getTime()) {
-        keys.push(format(currentTime, 'HH:mm'))
-        currentTime = addMinutes(currentTime, 1)
+    canvasConfig() {
+      // Trick to allow for recomputation of values on window resize
+      const windowWidth =
+        window.innerWidth +
+        this.recomputeCanvasWidth -
+        +this.recomputeCanvasWidth
+      return {
+        height: (this.heightOfLongestDay / 60) * 1.5,
+        width: Math.min(windowWidth - 100, 1000)
       }
-      const minutes = {}
-      keys.forEach((time) => {
-        minutes[time] = []
-      })
-      return minutes
     },
-    courses() {
-      return this.coursesIn(startOfWeek(new Date()), endOfWeek(new Date()), {
-        includeBothWeekTypes: true,
-        includeDeleted: true
-      })
-    },
-    minutes() {
-      // Structure:
-      /*
-        [
-          {
-            time: <HH:mm>
-            events: <Event>[]
-          }
-        ]
-      */
-      // In the DOM:
-      /*
-      <tr>
-        <td class="hour"> {{ time.minutes == 0 ? time : "" }} </td>
-        @each events
-          <td :data-weektype="week_type"> (<Event> markup...) </td>
-     */
-      let courses = this.courses
-      const flatGroups = []
-      // Add a `time` prop to each course in order to group them.
-      courses = courses.map((course) => {
-        let time = course.start
-        time = format(time, 'HH:mm', new Date())
-        return { ...course, time, empty: false }
-      })
-      const emptyEvent = { empty: true }
-      const dayIndexes = [1, 2, 3, 4, 5, 6]
-      Object.keys(this.emptyMinutes).forEach((time) => {
-        let events = {}
-        dayIndexes.forEach((day) => {
-          const matchingEvents = courses.filter(
-            (c) =>
-              isWithinInterval(parse(time, 'HH:mm', c.start), {
-                start: c.start,
-                end: c.end
-              }) && c.day === day
-          )
-          if (matchingEvents.length > 0) {
-            events[day] = matchingEvents.filter((c) => c.time === time)
-          } else {
-            events[day] = [emptyEvent]
-          }
-        })
-        if (time === '08:01')
-          console.log(
-            Object.values(events).filter(
-              (e) => e.filter((y) => !y.empty).length > 0
-            )
-          )
-        const emptyMinute =
-          Object.values(events).filter(
-            (e) => e.filter((y) => !y.empty).length > 0
-          ).length === 0
-        if (emptyMinute) events = {}
-        flatGroups.push({ time, events, hasEvents: !emptyMinute })
-      })
-      return flatGroups
+    colmunsCount() {
+      // Get an array of days of events (unique)
+      const days = [...new Set(this.events.map((event) => event.day))]
+      // Work week (excluding weekends)
+      let colmunsCount = 5
+      // If we have saturday, bump the column count to 6
+      if (days.includes(6)) {
+        colmunsCount = 6
+      }
+      // If we have sunday, bump to 7 (the whole week)
+      if (days.includes(7)) {
+        colmunsCount = 7
+      }
+      return colmunsCount
     }
   },
   mounted() {
-    this.$withLoadingScreen(async () => {
-      await this.$store.dispatch('settings/load')
+    window.addEventListener('resize', (ev) => {
+      this.recomputeCanvasWidth += 1
     })
-    window.iAmAMinimalist = () => {
-      console.log('<Ewen Le Bihan> Me too!')
-      console.log(
-        '<Ewen Le Bihan> btw, if you like mmnl music, please take a listen over at https://youtube.com/c/mx3_music'
-      )
-      console.log(
-        "<Ewen Le Bihan> (You also discovered schoolsyst's first easter egg, congrats!)"
-      )
-      console.log(
-        '%cTo turn the schedule back to normal, simply refresh the page',
-        'font-style: italic;'
-      )
-      document
-        .querySelectorAll('.schedule')
-        .forEach((el) => el.classList.add('mnml'))
-      return 'good choice!'
-    }
   },
   methods: {
-    ...mapActions('schedule', { patch: 'patchEvent', del: 'deleteEvent' }),
     ...mapGetters(['textColor']),
-    ...mapGetters('settings', { setting: 'value' }),
-    cellStyles(event) {
+    ...mapGetters('schedule', ['event']),
+    resolveWidth(event) {
+      // Get the total width the canvas should be
+      const total = this.canvasConfig.width
+      // The width is the total width divided by the number of columns there should be
+      let width = total / this.colmunsCount
+      // Half the width if its not on both week types
+      if (event.week_type !== 'BOTH') {
+        width /= 2
+      }
+      return width
+    },
+    resolveHeight(event) {
+      // Get the duration of this event
+      const duration = event.end - event.start
+      // Multiply by the factor
+      return (duration / 60) * 1.5
+    },
+    resolvePosition(event) {
+      // Get the day and multiply by the base width of an event
+      const baseWidth = this.resolveWidth({ week_type: 'BOTH' })
+      let x = baseWidth * event.day - baseWidth
+      // If the event is in Q2, we need to offset it to the right
+      if (event.week_type === 'Q2') x += baseWidth / 2
+      // Get the start time of the first event for this day
+      const eventsOfDay = this.events.filter((e) => e.day === event.day)
+      const startOfDay = Math.min(...eventsOfDay.map((e) => e.start))
+      // Get the difference between the start of the day and the start of this event,
+      // Multiply by the height factor
+      const y = ((event.start - startOfDay) / 60) * 1.5
+      return { x, y }
+    },
+    resolveRect(event) {
+      const { x, y } = this.resolvePosition(event)
       return {
-        color: this.textColor()(event.subject.color),
-        backgroundColor: event.subject.color,
-        borderTopColor: event.subject.color,
-        borderBottomColor: event.subject.color
+        width: this.resolveWidth(event),
+        height: this.resolveHeight(event),
+        x,
+        y,
+        fill: event.subject.color
       }
     },
-    cellRowspan(event) {
-      const diff = differenceInMinutes(event.start, event.end)
-      const minutes = Math.abs(diff)
-      return minutes
-    },
-    cellColspan(event) {
-      let colspan = 2
-      if (event.week_type !== 'BOTH' && this.bothWeeks) {
-        colspan = 1
+    resolveText(event) {
+      const rect = this.resolveRect(event)
+      return {
+        text: event.subject.name + '\n' + event.room,
+        fontFamily: 'Now, sans-serif',
+        y: rect.y,
+        x: rect.x,
+        width: rect.width,
+        height: rect.height,
+        align: 'center',
+        verticalAlign: 'middle',
+        fontSize: 15,
+        wrap: 'none',
+        ellipsis: true,
+        padding: 3,
+        fill: this.textColor()(rect.fill),
+        lineHeight: 1.5,
+        id: event.uuid
       }
-      return colspan
     },
-    cellAttrs(event) {
-      if (event.empty)
-        return {
-          class: 'empty',
-          colspan: 2
-        }
-      else
-        return {
-          style: this.cellStyles(event),
-          colspan: this.cellColspan(event),
-          rowspan: this.cellRowspan(event)
-        }
-    },
-    cellOnClick(event) {
-      if (event.empty) return
-      this.editingEvent = event
+    handleEventClick(vueComponent) {
+      const eventUUID = vueComponent.target.attrs.id
+      this.editingEvent = this.event()(eventUUID)
       this.$modal.open('edit-event')
-      this.$emit('event-click', event)
     }
   }
 }
 </script>
-
-<style lang="stylus" scoped>
-.schedule
-  overflow-x auto
-table
-  table-layout fixed
-  width 100%
-  min-width 6 * 7rem
-  border-collapse collapse
-thead
-  td
-    height 1.5rem
-    text-align center
-.week-type
-  color var(--grey)
-
-td.time
-  border-right 2px solid var(--grey)
-  height 5rem
-  font-family var(--fonts-monospace-light)
-  width 5 * 1ch + .5em
-  text-align right
-  padding 1em
-  vertical-align top
-tr.new-hour
-  // min-height 1rem
-  border-top 2px solid var(--grey)
-
-.event:not(.empty)
-  height 2rem
-  text-align center
-  padding 0.5em
-  cursor pointer
-  .room
-    opacity: 0.75
-    font-family var(--fonts-monospace-light)
-  .subject
-    overflow-x hidden
-    overflow-y visible
-    width 100%
-    text-overflow ellipsis
-    white-space normal
-.event.empty
-  height: 0 !important
-
-.schedule.mnml
-  thead
-    opacity: 0
-  .time
-    opacity: 0
-  td, tr
-    border: none
-</style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -116,6 +116,7 @@ export default {
     '~plugins/loading-screen',
     '~plugins/vue-chartkick',
     '~plugins/v-tooltip.js',
+    '~plugins/vue-konva.js',
     '~plugins/vue2-touch-events',
     { src: '~plugins/ga.js', mode: 'client' }
   ],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "nuxt start",
     "generate": "nuxt generate",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
-    "test": "cross-env NODE_ENV=test jest"
+    "test": "cross-env NODE_ENV=test jest",
+    "dev-backend": "cd ../schoolsyst-api && poetry run python manage.py runserver 9999"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -63,6 +64,7 @@
     "fuse.js": "^3.4.5",
     "js-search": "^1.4.3",
     "jwt-decode": "^2.2.0",
+    "konva": "^4.2.2",
     "lodash.debounce": "^4.0.8",
     "lodash.flatten": "^4.4.0",
     "lodash.groupby": "^4.6.0",
@@ -89,6 +91,7 @@
     "vue-context": "^5.0.0",
     "vue-context-menu": "^2.0.6",
     "vue-infinite-loading": "^2.4.4",
+    "vue-konva": "^2.1.1",
     "vue-multiselect": "^2.1.6",
     "vue2-touch-events": "^2.1.0",
     "vuex-persist": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "js-search": "^1.4.3",
     "jwt-decode": "^2.2.0",
     "konva": "^4.2.2",
+    "lodash.clamp": "^4.0.3",
     "lodash.debounce": "^4.0.8",
     "lodash.flatten": "^4.4.0",
     "lodash.groupby": "^4.6.0",

--- a/pages/schedule/index.vue
+++ b/pages/schedule/index.vue
@@ -8,11 +8,12 @@
           CardMutation(v-bind="mutation")
     .schedule
       HeadingSub Emploi du temps
-      Schedule(:now="scheduleDate")
+      Schedule(:events="events")
 </template>
 
 <script>
 import { mapGetters, mapState } from 'vuex'
+import { getUnixTime, addDays } from 'date-fns'
 import Schedule from '~/components/Schedule.vue'
 import HeadingSub from '~/components/HeadingSub.vue'
 import ButtonNormal from '~/components/ButtonNormal.vue'
@@ -27,10 +28,24 @@ export default {
     ...mapGetters('schedule', ['mutations']),
     scheduleDate() {
       return this.now
+    },
+    events() {
+      return this.coursesIn()(
+        this.scheduleDate,
+        addDays(this.scheduleDate, 7)
+      ).map((event) => ({
+        ...event,
+        start: getUnixTime(event.start),
+        end: getUnixTime(event.end),
+        week_type: 'BOTH'
+      }))
     }
   },
   async mounted() {
     await this.$store.dispatch('schedule/load')
+  },
+  methods: {
+    ...mapGetters('schedule', ['coursesIn'])
   }
 }
 </script>

--- a/pages/setup/schedule/events.vue
+++ b/pages/setup/schedule/events.vue
@@ -9,7 +9,7 @@
     h1 Rentrez votre emploi du temps
     .schedule
       ButtonNormal.add(variant="outline" @click="$modal.show('add-event')") Ajouter
-      Schedule(both-weeks)
+      Schedule(both-weeks :events="events")
     TheBottomBar
       ButtonNormal(variant="text-blue" href="/setup/schedule/settings") #[Icon arrow_back] Retour
       ButtonNormal.to-right(variant="primary" href="/") Terminer
@@ -17,6 +17,7 @@
 
 <script>
 import { mapActions } from 'vuex'
+import { parse, getUnixTime } from 'date-fns'
 import TheBottomBar from '~/components/TheBottomBar.vue'
 import ButtonNormal from '~/components/ButtonNormal.vue'
 import ModalDialogConfirm from '~/components/ModalDialogConfirm.vue'
@@ -53,6 +54,13 @@ export default {
   computed: {
     settings() {
       return this.$store.getters['settings/fromCategory']('Emploi du temps')
+    },
+    events() {
+      return this.$store.getters['schedule/events'].map((event) => ({
+        ...event,
+        start: getUnixTime(parse(event.start, 'HH:mm:ss', new Date(0))),
+        end: getUnixTime(parse(event.end, 'HH:mm:ss', new Date(0)))
+      }))
     }
   },
   mounted() {
@@ -91,4 +99,7 @@ ul.settings
 .schedule
   // Compensate for the bottom bar
   margin-bottom: 96px
+  display flex
+  align-items center
+  flex-direction column
 </style>

--- a/plugins/vue-konva.js
+++ b/plugins/vue-konva.js
@@ -1,0 +1,4 @@
+import Vue from 'vue'
+import VueKonva from 'vue-konva'
+
+Vue.use(VueKonva)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7445,6 +7445,11 @@ known-css-properties@^0.14.0:
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.14.0.tgz#d7032b4334a32dc22e6e46b081ec789daf18756c"
   integrity sha512-P+0a/gBzLgVlCnK8I7VcD0yuYJscmWn66wH9tlKsQnmVdg689tLEmziwB9PuazZYLkcm07fvWOKCJJqI55sD5Q==
 
+konva@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/konva/-/konva-4.2.2.tgz#0f1799dbe0275bb8218a03549ce931e9006a696d"
+  integrity sha512-5vq/rKy35/gdMLipjcxgFz/LhJ/S8Ct/e1XntQmH1MSwN4rMP97Oera2PzxDh3DZPsrV6TETTKHNb1G7Jb6Z5A==
+
 last-call-webpack-plugin@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz#9742df0e10e3cf46e5c0381c2de90d3a7a2d7555"
@@ -12938,6 +12943,11 @@ vue-jest@^3.0.5:
     source-map "^0.5.6"
     tsconfig "^7.0.0"
     vue-template-es2015-compiler "^1.6.0"
+
+vue-konva@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/vue-konva/-/vue-konva-2.1.1.tgz#b6392e4468ff4db5d5838fe2f58fd700cce6f3cd"
+  integrity sha512-Lhd1+P8k5Sey93s/Ov1LPty6bMHWJkgZxJztKaBM3kbwYpLZQX1b/33PBuU2kPiIejjlFdJrU/rCS78fkkcXpw==
 
 vue-loader@^15.8.3:
   version "15.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7697,6 +7697,11 @@ lodash.camelcase@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
+lodash.clamp@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.clamp/-/lodash.clamp-4.0.3.tgz#5c24bedeeeef0753560dc2b4cb4671f90a6ddfaa"
+  integrity sha1-XCS+3u7vB1NWDcK0y0Zx+Qpt36o=
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"


### PR DESCRIPTION
The previous approchain was supposed to be eaiser because schedules are essentially tables, and using native HTML elements seemed like the "purest" thing to do.

However, this was a disaster, see the associated issue for more details.

Concerning performance, this was also a trainwreck because having ≈600 `<tr>`s, each containing upwards of tens of `<td>`, and calculating the offsets, adding *ghost cells* to push down cells was just not the right thing to do.

This approach leverages the `<canvas>` element, and uses the library [KonvaJS](https://konvajs.org/) and its wrapper for VueJS, [vue-konva](https://konvajs.org/docs/vue/index.html).

The width, height and position calculations are designed to be responsive, and the canvas indeed changes width to adapt to `resize` events.

This PR is not finished, some things are still in progress:

- [x] Bring back table headers (day names & week types)
- [x] Limit the width to a minimum (right now it becomes ridiculous on mobile devices, it should just scroll horizontally)
- [x] For some reason the [`<ModalAddEvent>`](https://github.com/schoolsyst/frontend/blob/canvas-based-schedule-renderer/components/ModalAddEvent.vue) refuses to parse start & end dates and thus no interaction is possible with events (although adding events works fine), fix this.

The following tasks are rendered easy by using a canvas, and will or not be added to this PR:

- [ ] Add animations on addition/removal of events
- [ ] Allow users to drag-and-drop events to move them (will be quite hard but much more doable than if we were using the previous `<table>`-based renderer)

This PR closes #49.